### PR TITLE
#24 option to disable reasoning summaries for azure accounts that have not gone through the needed verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In addition to updating the OpenAI Base URL, you need to:
 
 2. Ensure the toggles for both options are **on**, as shown in the previous image.
 
-3. Add the custom models called exactly `gpt-high`, `gpt-medium`, and `gpt-low`, as shown in the previous image. You don't need to remove other models.
+3. Add the custom models called exactly `gpt-high`, `gpt-medium`, and `gpt-low`, as shown in the previous image. You can also create `gpt-minimal` for minimal reasoning effort. You don't need to remove other models.
 
 <details>
 <summary>Additional steps if you face this error:

--- a/README.md
+++ b/README.md
@@ -37,27 +37,27 @@ If you prefer to deploy the service (for example, to allow multiple members of y
 
 ### 1. Service configuration
 
-Make a copy of the file `.env.example` as `.env` and update the following flags:
+Make a copy of the file `.env.example` as `.env` and update the following flags as needed:
 
-| Flag               | Description                                                                                          | Default     |
-| ------------------ | ---------------------------------------------------------------------------------------------------- | ----------- |
-| `AZURE_BASE_URL`   | Your Azure OpenAI endpoint base URL (no trailing slash), e.g. `https://<resource>.openai.azure.com`. | required    |
-| `AZURE_API_KEY`    | Azure OpenAI API key.                                                                                | required    |
-| `AZURE_DEPLOYMENT` | Name of the Azure model deployment to use.                                                           | `gpt-5`     |
-| `SERVICE_API_KEY`  | Arbitrary API key to protect your service. Set it to a random string.                                | `change-me` |
+| Flag                  | Description                                                                                                                    | Default     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| `AZURE_BASE_URL`      | Your Azure OpenAI endpoint base URL (no trailing slash), e.g. `https://<resource>.openai.azure.com`.                           | required    |
+| `AZURE_API_KEY`       | Azure OpenAI API key.                                                                                                          | required    |
+| `AZURE_DEPLOYMENT`    | Name of the Azure model deployment to use.                                                                                     | `gpt-5`     |
+| `SERVICE_API_KEY`     | Arbitrary API key to protect your service. Set it to a random string.                                                          | `change-me` |
+| `AZURE_SUMMARY_LEVEL` | Set to `none` to disable summaries. You might have to disable them if your organization hasn't been approved for this feature. | `detailed`  |
 
 Alternatively, you can pass them through the environment where you run the application.
 
 <details>
 <summary>Optional Configuration</summary>
 
-| Flag                  | Description                                                            | Default              |
-| --------------------- | ---------------------------------------------------------------------- | -------------------- |
-| `AZURE_API_VERSION`   | Azure OpenAI Responses API version to call.                            | `2025-04-01-preview` |
-| `AZURE_SUMMARY_LEVEL` | Reasoning summary level for responses.                                 | `detailed`           |
-| `AZURE_TRUNCATION`    | Truncation strategy for long inputs.                                   | `auto`               |
-| `FLASK_ENV`           | Flask environment. Use `development` for dev or `production` for prod. | `production`         |
-| `RECORD_TRAFFIC`      | Toggle writing request/response traffic to `recordings/`               | `off`                |
+| Flag                | Description                                                            | Default              |
+| ------------------- | ---------------------------------------------------------------------- | -------------------- |
+| `AZURE_API_VERSION` | Azure OpenAI Responses API version to call.                            | `2025-04-01-preview` |
+| `AZURE_TRUNCATION`  | Truncation strategy for long inputs.                                   | `auto`               |
+| `FLASK_ENV`         | Flask environment. Use `development` for dev or `production` for prod. | `production`         |
+| `RECORD_TRAFFIC`    | Toggle writing request/response traffic to `recordings/`               | `off`                |
 
 </details>
 

--- a/app/azure/request_adapter.py
+++ b/app/azure/request_adapter.py
@@ -234,9 +234,9 @@ class RequestAdapter:
         responses_body["stream"] = True
 
         reasoning_effort = inbound_model.replace("gpt-", "").lower()
-        if reasoning_effort not in {"high", "medium", "low"}:
+        if reasoning_effort not in {"high", "medium", "low", "minimal"}:
             raise ValueError(
-                "Model name must be either gpt-high, gpt-medium, or gpt-low"
+                "Model name must be either gpt-high, gpt-medium, gpt-low, or gpt-minimal"
             )
 
         responses_body["reasoning"] = {

--- a/app/azure/request_adapter.py
+++ b/app/azure/request_adapter.py
@@ -241,8 +241,12 @@ class RequestAdapter:
 
         responses_body["reasoning"] = {
             "effort": reasoning_effort,
-            "summary": settings["AZURE_SUMMARY_LEVEL"],
         }
+
+        # Concise is not supported by GPT-5,
+        # but allowing it for now to be able to test it on other models
+        if settings["AZURE_SUMMARY_LEVEL"] in {"auto", "detailed", "concise"}:
+            responses_body["reasoning"]["summary"] = settings["AZURE_SUMMARY_LEVEL"]
 
         responses_body["store"] = False
         responses_body["stream_options"] = {"include_obfuscation": False}


### PR DESCRIPTION
Closes #24 by adding the option

```
AZURE_SUMMARY_LEVEL=none
```

Also found out about "minimal" reasoning effort and added support for it through the model name "gpt-minimal"