### PR TITLE
Fix #37 Improve 401 resporting

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -20,6 +20,15 @@ def require_auth(func):
         if valid_brearer_token():
             return func(*args, **kwargs)
         else:
-            return Response("Unauthorized", 401)
+            error_message = (
+                "\nAuthentication with Cursor-Azure-GPT-5 service failed.\n\n"
+                "These value of:\n"
+                "\tCursor Settings > Models > API Keys > OpenAI API Key\n\n"
+                "Must match the value of:\n"
+                "\tSERVICE_API_KEY in your .env file\n\n"
+                "Ensure the values match exactly, and try again.\n"
+                "If modifying the .env file, restart the service for the changes to apply."
+            )
+            return Response(error_message, 400)
 
     return wrapper

--- a/app/azure/adapter.py
+++ b/app/azure/adapter.py
@@ -86,6 +86,7 @@ class AzureAdapter:
             "endpoint": re.sub(
                 r"(//.)(.*?)(.\.)", "\\1***\\3", request_kwargs.get("url")
             ),
+            "azure_status_code": resp.status_code,
             "azure_response": resp_content,
             "request_body": body,
         }
@@ -102,5 +103,5 @@ class AzureAdapter:
         console.print(error_message)
         return Response(
             error_message,
-            status=resp.status_code,
+            status=resp.status_code if resp.status_code != 401 else 400,
         )

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -17,9 +17,9 @@ class TestConfig:
 class TestModels:
     """Models."""
 
-    def test_models_endpoint_returns_200(self, testapp):
-        """Ensure /models endpoint returns HTTP 200."""
-        testapp.get("/models", status=401)
+    def test_models_endpoint_returns_400(self, testapp):
+        """Ensure /models endpoint returns HTTP 400."""
+        testapp.get("/models", status=400)
 
     def test_health_endpoint_returns_200(self, testapp):
         """Ensure /health endpoint returns HTTP 200."""


### PR DESCRIPTION
Now errors should look like this:

### Bad AZURE_BASE_URL and/or AZURE_API_KEY

<img width="1191" height="1375" alt="Image" src="https://github.com/user-attachments/assets/0dd8290f-c758-4950-9e51-e008eb470133" />

### OpenAI API Key is different from  SERVICE_API_KEY

<img width="1191" height="769" alt="Image" src="https://github.com/user-attachments/assets/337163b3-9317-42ab-8b5e-8272e1c122ef" />

### Bad cursor configuration and/or model name

<img width="1191" height="405" alt="Image" src="https://github.com/user-attachments/assets/6feebbad-7490-4bb4-a5ca-9e4cbee674d4" />