### PR TITLE
Update model verification status in Supported Models list

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ The proxy accepts these Cursor-facing model IDs in parallel. Configure one Azure
 | `gpt-5.4-nano` | Verified |
 | `gpt-5.3-codex` | Verified |
 | `gpt-5.2` | Expected to work (same Responses API) |
-| `gpt-5.2-codex` | Expected to work (same Responses API) |
+| `gpt-5.2-codex` | Verified |
 | `gpt-5.1` | Expected to work (same Responses API) |
 | `gpt-5.1-codex` | Expected to work (same Responses API) |
 | `gpt-5.1-codex-max` | Expected to work (same Responses API) |
-| `gpt-5.1-codex-mini` | Expected to work (same Responses API) |
+| `gpt-5.1-codex-mini` | Verified |
 | `gpt-5` | Expected to work (same Responses API) |
-| `gpt-5-mini` | Expected to work (same Responses API) |
+| `gpt-5-mini` | Verified |
 | `gpt-5-codex` | Expected to work (same Responses API) |
 
 **Verified** = manually tested end-to-end with a real Cursor client through the proxy to Azure. **Expected to work** = these models use the same Azure Responses API surface, but have not been individually verified. If you test one and it works (or doesn't), please [open an issue](https://github.com/gabrii/Cursor-Azure-GPT-5/issues) so we can update this table.


### PR DESCRIPTION

Updates the README Supported Models table to mark additional Cursor-facing model IDs as verified after manual end-to-end testing through the proxy to Azure.

Specifically, this PR changes the verification status for:
- `gpt-5.2-codex`
- `gpt-5.1-codex-mini`
- `gpt-5-mini`

from “Expected to work” to “Verified”.

<img width="657" height="155" alt="螢幕擷取畫面 2026-04-28 165756" src="https://github.com/user-attachments/assets/bcd1526f-8a72-41e5-ac19-d86869590a5b" />
<img width="651" height="179" alt="螢幕擷取畫面 2026-04-28 165616" src="https://github.com/user-attachments/assets/07872c62-a8b0-45f9-95a6-b212900170ec" />
<img width="657" height="147" alt="螢幕擷取畫面 2026-04-28 170006" src="https://github.com/user-attachments/assets/aea3a669-d8f1-4e29-8822-f505c268456e" />
